### PR TITLE
Haplotype/Sequence context aware comparison of indels

### DIFF
--- a/etc/evaluator.py
+++ b/etc/evaluator.py
@@ -223,7 +223,7 @@ def evaluate(submission, truth, vtype='SNV', reffa=None, ignorechroms=None, igno
                 for trurec in truvcfh.fetch(subrec.CHROM, startpos, end=endpos):
                     if match(subrec, trurec, vtype=vtype) and str(trurec) not in used_truth:
                         matched = True
-                if not matched and subrec.is_indel and reffa_fh:# try haplotype aware comparion
+                if not matched and subrec.is_indel and reffa_fh:# try haplotype aware comparison
                     window = 100
                     for (trurec, d) in get_close_matches(subrec, truvcfh, window, indels_only=True):
                         if str(trurec) in used_truth:
@@ -231,7 +231,7 @@ def evaluate(submission, truth, vtype='SNV', reffa=None, ignorechroms=None, igno
                         if have_identical_haplotypes(subrec, trurec, reffa_fh):
                             matched = True
                             if debug:
-                                print "DEBUG: Rescueing %s which has same haplotype as %s\n" % (subrec, trurec)
+                                print "DEBUG: Rescuing %s which has same haplotype as %s" % (subrec, trurec)
                             break
             if matched:
                 used_truth[str(trurec)] = True
@@ -278,7 +278,7 @@ def main(args):
         sys.stderr.write("-m/--mutype must be either SV, SNV, or INDEL\n")
         sys.exit(1)
 
-    result = evaluate(args.subvcf, args.truvcf, vtype=args.mutype, reffa=args.reffa, ignorechroms=chromlist, ignorepass=args.nonpass, printfp=args.printfp, debug=False)
+    result = evaluate(args.subvcf, args.truvcf, vtype=args.mutype, reffa=args.reffa, ignorechroms=chromlist, ignorepass=args.nonpass, printfp=args.printfp, debug=args.debug)
 
     print "precision, recall, F1 score: " + ','.join(map(str, result))
 
@@ -291,5 +291,6 @@ if __name__ == '__main__':
     parser.add_argument('--ignore', dest='chromlist', default=None, help="(optional) comma-seperated list of chromosomes to ignore")
     parser.add_argument('--nonpass', dest='nonpass', action="store_true", help="evaluate all records (not just PASS records) in VCF")
     parser.add_argument('--printfp', dest='printfp', action="store_true", help="output false positive positions")
+    parser.add_argument('--debug', dest='debug', action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Two differently annotated indels can "produce" the same haplotype or sequence, due to the positional ambiguity in indel notation. Simplest example is the deletion of bases at different positions in a homopolymer stretch. Evaluators would normally see two different indels. If one was known to be true, the other would be (wrongly) evaluated as false. The solution to this problem is to insert the indels into their reference sequence context and compare the two resulting mutated sequences. This pull request adds (optional) haplotype or sequence context aware comparison to the evaluation of indel calls (enabled by providing a reference to evaluator.py with -f or --ref)
- Also added --debug option
- Introduces a pysam dependency to be able to read the reference (0.7.5 worked; newer versions esp. 0.8 might not work)
- Was initially part of closed pull request #18

Following is an example of two indels that result in identically mutated sequences (corresponding reference http://www.ncbi.nlm.nih.gov/nuccore/NC_000913.3) 
- Sequence context for first indel is: `361131 CGTGCAT`
- Sequence context for first indel is: `4230169 TCTGGCTTTTACGCCGCGCCAGTGGAGGTTGAA`

Truth vcf:

```
#CHROM  POS ID  REF ALT QUAL    FILTER  INFO    FORMAT  SPIKEIN
NC_000913   361132  .   G   GTG 100 PASS    SOMATIC GT  0/1
NC_000913   4230170 .   C   CTGGCTTTTACGCCGC    100 PASS    SOMATIC GT  0/1
```

Submission vcf:

```
#CHROM  POS ID  REF ALT QUAL    FILTER  INFO
NC_000913   361131  .   C   CGT 312 PASS    DP=598;AF=0.202341;SB=45;DP4=256,229,38,83;INDEL
NC_000913   4230169 .   T   TCTGGCTTTTACGCCG    84  PASS    DP=577;AF=0.053726;SB=5;DP4=276,275,19,12;INDEL
```

Andreas
