### PR TITLE
Added Exception if the --minvaf value is bigger than the --maxvaf

### DIFF
--- a/scripts/randomsites.py
+++ b/scripts/randomsites.py
@@ -54,7 +54,7 @@ class Genome:
 
         else:
             goodmut = False
-            while not goodmut: 
+            while not goodmut:
                 rchrom = random.choice(self.chrmap)
                 rpos   = int(random.uniform(1, self.chrlen[rchrom]))
 
@@ -70,7 +70,7 @@ class Genome:
 def randomseq(len):
     ''' make a random DNA sequence '''
     return ''.join([random.choice(['A','T','G','C']) for _ in range(int(len))])
-    
+
 
 def randomsv():
     ''' random SV information '''
@@ -168,6 +168,7 @@ def main(args):
     if args.seed is not None:
         random.seed(int(args.seed))
 
+    assert args.minvaf < args.maxvaf, "--minvaf( = %s) is higher than --maxvaf ( = %s)" % (args.minvaf, args.maxvaf)
     assert os.path.exists(args.genome + '.fai'), "reference FASTA not indexed: " + args.genome
 
     g = Genome(args.genome, bedfile=args.bed)
@@ -194,16 +195,16 @@ if __name__ == '__main__':
     parser_indel = subparsers.add_parser('indel')
     parser_indel.add_argument('--minlen', default=1,  help='minimum SV contig length (default = 1)')
     parser_indel.add_argument('--maxlen', default=90, help='maximum SV contig length (default = 90)')
-    parser_indel.add_argument('--lenbeta1', default=0.5, help='left shape parameter for beta dist. of indel lengths (default = 0.5)') 
-    parser_indel.add_argument('--lenbeta2', default=4.0, help='right shape parameter for beta dist. of indel lengths (default = 4.0)') 
+    parser_indel.add_argument('--lenbeta1', default=0.5, help='left shape parameter for beta dist. of indel lengths (default = 0.5)')
+    parser_indel.add_argument('--lenbeta2', default=4.0, help='right shape parameter for beta dist. of indel lengths (default = 4.0)')
     parser_indel.set_defaults(func=run_indel)
 
     parser_sv = subparsers.add_parser('sv')
     parser_sv.add_argument('--minlen', default=3000,  help='minimum SV contig length (default = 3000)')
     parser_sv.add_argument('--maxlen', default=30000, help='maximum SV contig length (default = 30000)')
-    parser_sv.add_argument('--lenbeta1', default=1.0, help='left shape parameter for beta dist. of indel lengths (default = 1.0)') 
+    parser_sv.add_argument('--lenbeta1', default=1.0, help='left shape parameter for beta dist. of indel lengths (default = 1.0)')
     parser_sv.add_argument('--lenbeta2', default=1.0, help='right shape parameter for beta dist. of indel lengths (default = 1.0)')
-    parser_sv.add_argument('--cnvfile', default='cnvs.txt', help='output file for CNV information (used for SV VAF)') 
+    parser_sv.add_argument('--cnvfile', default='cnvs.txt', help='output file for CNV information (used for SV VAF)')
     parser_sv.set_defaults(func=run_sv)
 
     args = parser.parse_args()


### PR DESCRIPTION
The reasoning is that since the default value of --minvaf ==  0.25,
    setting max to 0.2 leads to weird behaviour:

    $python randomsites.py --bed /data/tests/data/test_bed_chr5.bed
      --seed 1 --numpicks 10 -g /ref/hg38.fa --maxvaf 0.2 snv

    chr5    18086005        18086005        0.216723292259
    chr5    18086028        18086028        0.218003808265
    chr5    18086031        18086031        0.239807878579
    chr5    18086001        18086001        0.218369583188
    chr5    18086002        18086002        0.21761330621
    chr5    18086037        18086037        0.242244180094
    chr5    18086034        18086034        0.209926045473
    chr5    18086037        18086037        0.206308224477
    chr5    18086034        18086034        0.24011565286
    chr5    18086014        18086014        0.22536149376