### PR TITLE
specify PyVCF as required dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,5 +135,6 @@ setup(name='bamsurgeon',
 	packages=find_packages(),
     install_requires = [
         'pysam>=0.8.1',
+        'PyVCF',
     ],
 	)


### PR DESCRIPTION
PyVCF was not specified as a dependency in `setup.py`, even though some scripts (like `evaluator.py`) have an unguarded `import vcf`.