### PR TITLE
Fix SNVs in overlapping positions of PE data - "ignore_overlaps=False"

### DIFF
--- a/bamsurgeon/mutation.py
+++ b/bamsurgeon/mutation.py
@@ -184,7 +184,7 @@ def mutate(args, log, bamfile, bammate, chrom, mutstart, mutend, mutpos_list, av
 
     maxfrac = None
 
-    for pcol in bamfile.pileup(reference=chrom, start=mutstart-1, end=mutend+1, max_depth=int(args.maxdepth)):
+    for pcol in bamfile.pileup(reference=chrom, start=mutstart-1, end=mutend+1, max_depth=int(args.maxdepth), ignore_overlaps=False):
         if pcol.pos:
             if args.ignorepileup and (pcol.pos < mutstart-1 or pcol.pos > mutend+1):
                 continue


### PR DESCRIPTION
Fixes the issue that SNVs would only be introduced in one read of a pair at positions where both reads overlap, as described in: https://github.com/adamewing/bamsurgeon/issues/132
Pysam's pileup would by default only return one read of a pair, if both overlap at the position of interest. Including the `ignore_overlaps=False` parameter in the pileup call fixed this bug for me.