### PR TITLE
docs: Add --recurse-submodules to htslib cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following presumes $HOME/bin is in your $PATH
 Samtools / BCFTools / wgsim:
 
 ```
-git clone https://github.com/samtools/htslib.git
+git clone --recurse-submodules --remote-submodules https://github.com/samtools/htslib.git
 make -C htslib
 
 git clone https://github.com/samtools/samtools.git


### PR DESCRIPTION
`samtools` requires the git submodule `htscodecs` (in `htslib` repository) to be loaded before compilation.