### PR TITLE
fix: Switch to ProcessPoolExecutor

### DIFF
--- a/bin/addindel.py
+++ b/bin/addindel.py
@@ -15,7 +15,7 @@ from bamsurgeon.common import *
 from uuid import uuid4
 from re import sub
 from shutil import move
-from multiprocessing import Pool
+from concurrent.futures import ProcessPoolExecutor
 from collections import defaultdict as dd
 
 import logging
@@ -318,7 +318,7 @@ def main(args):
     assert os.path.exists('addindel_logs_' + os.path.basename(args.outBamFile)), "could not create output directory!"
     assert os.path.exists(args.tmpdir), "could not create temporary directory!"
 
-    pool = Pool(processes=int(args.procs))
+    pool = ProcessPoolExecutor(processes=int(args.procs))
     results = []
 
     ntried = 0
@@ -337,12 +337,12 @@ def main(args):
                 ins = c[5]
 
             # make mutation (submit job to thread pool)
-            result = pool.apply_async(makemut, [args, chrom, start, end, vaf, ins, avoid, alignopts])
+            result = pool.submit(makemut, args, chrom, start, end, vaf, ins, avoid, alignopts)
             results.append(result)
             ntried += 1
 
     for result in results:
-        tmpbamlist = result.get()
+        tmpbamlist = result.result()
         if tmpbamlist is not None:
             for tmpbam in tmpbamlist:
                 if os.path.exists(tmpbam):

--- a/bin/addindel.py
+++ b/bin/addindel.py
@@ -318,7 +318,7 @@ def main(args):
     assert os.path.exists('addindel_logs_' + os.path.basename(args.outBamFile)), "could not create output directory!"
     assert os.path.exists(args.tmpdir), "could not create temporary directory!"
 
-    pool = ProcessPoolExecutor(processes=int(args.procs))
+    pool = ProcessPoolExecutor(max_workers=int(args.procs))
     results = []
 
     ntried = 0

--- a/bin/addsnv.py
+++ b/bin/addsnv.py
@@ -356,7 +356,7 @@ def main(args):
     assert os.path.exists('addsnv_logs_' + os.path.basename(args.outBamFile)), "could not create output directory!"
     assert os.path.exists(args.tmpdir), "could not create temporary directory!"
 
-    pool = ProcessPoolExecutor(processes=int(args.procs))
+    pool = ProcessPoolExecutor(max_workers=int(args.procs))
     results = []
 
     ntried = 0

--- a/bin/addsv.py
+++ b/bin/addsv.py
@@ -928,7 +928,7 @@ def main(args):
         sys.exit(1)
 
     results = []
-    pool = ProcessPoolExecutor(processes=int(args.procs))
+    pool = ProcessPoolExecutor(max_workers=int(args.procs))
 
     nmuts = 0
 


### PR DESCRIPTION
Switching from `Pool` to `ProcessPoolExecutor` allows to retrieve exceptions raised during `makemut()` and also catches exceptions when a process is killed by the OS due to high memory usage. Previously, `Pool` just entered in a deadlock. This will make it easier for users to debug their executions.