### PR TITLE
update BAMsurgeon installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python3 -O scripts/check_dependencies.py
 It is not necessary to install BAMSurgeon. It works as any other standalone Python script. Usage example:
 
 ```
-python3 -O bin/addsv.py -p 1 -v test_data/test_sv.txt -f test_data/testregion_realign.bam -r $REF -o test_data/testregion_sv_mut.bam --aligner mem --keepsecondary --seed 1234 --inslib test_data/test_inslib.fa
+python3 -O bin/addsv.py -p 1 -v test_data/test_sv.txt -f test_data/testregion_realign.bam -r test_data/Homo_sapiens_chr22_assembly19.fasta -o test_data/testregion_sv_mut.bam --aligner mem --keepsecondary --seed 1234 --inslib test_data/test_inslib.fa
 ```
 
 **For best performance, it is strongly recommended to run all scripts with the `-O` Python parameter to skip all assertion checks.**

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ autoreconf -i
 Velvet
 
 ```
-wget https://www.ebi.ac.uk/~zerbino/velvet/velvet_1.2.10.tgz
-tar xvzf velvet_1.2.10.tgz
-make -C velvet_1.2.10
-cp velvet_1.2.10/velvetg $HOME/bin
-cp velvet_1.2.10/velveth $HOME/bin
+git clone https://github.com/dzerbino/velvet.git
+cd velvet
+make
+cp velvetg $HOME/bin
+cp velveth $HOME/bin
 ```
 
 Pysam


### PR DESCRIPTION
hi @adamewing, 

Nowadays if you install velvet via the EBI website you get,

`ERROR 404: Not Found.
`

I updated the README.md file to download Velvet from github instead

Also the example command in the README uses a variable $REF, which isn't defined. I replaced this with the path to the test_data reference genome

Signed-off-by: William Brandler <wbrandler@exactsciences.com>