### PR TITLE
Added vcf parameter to addsnv.py

### DIFF
--- a/bin/addsnv.py
+++ b/bin/addsnv.py
@@ -431,7 +431,7 @@ def main(args):
     var_basename = '.'.join(os.path.basename(args.varFileName).split('.')[:-1])
     bam_basename = '.'.join(os.path.basename(args.outBamFile).split('.')[:-1])
 
-    vcf_fn = bam_basename + '.addsnv.' + var_basename + '.vcf'
+    vcf_fn = args.vcf + bam_basename + '.addsnv.' + var_basename + '.vcf'
 
     makevcf.write_vcf_snv('addsnv_logs_' + os.path.basename(args.outBamFile), args.refFasta, vcf_fn)
 
@@ -472,6 +472,7 @@ def run():
     parser.add_argument('--alignopts', default=None, help='aligner-specific options as comma delimited list of option1:value1,option2:value2,...')
     parser.add_argument('--tmpdir', default='addsnv.tmp', help='temporary directory (default=addsnv.tmp)')
     parser.add_argument('--seed', default=None, help='seed random number generation')
+    parser.add_argument('--vcf', default='', help="Path for the output VCF file. If not provided, the file will be saved in the current directory.")
     args = parser.parse_args()
 
     if 'BAMSURGEON_PICARD_JAR' in os.environ:

--- a/doc/Manual.tex
+++ b/doc/Manual.tex
@@ -52,7 +52,7 @@ usage: addsnv.py [-h] -v VARFILENAME -f BAMFILENAME -r REFFASTA -o OUTBAMFILE
                  [--ignoreref] [--force] [--insane] [--single]
                  [--maxopen MAXOPEN] [--requirepaired] [--tagreads]
                  [--skipmerge] [--ignorepileup] [--aligner ALIGNER]
-                 [--alignopts ALIGNOPTS] [--tmpdir TMPDIR] [--seed SEED]
+                 [--alignopts ALIGNOPTS] [--tmpdir TMPDIR] [--seed SEED] [--vcf]
 
 adds SNVs to reads, outputs modified reads as .bam along with mates
 
@@ -117,6 +117,7 @@ optional arguments:
                         option1:value1,option2:value2,...
   --tmpdir TMPDIR       temporary directory (default=addsnv.tmp)
   --seed SEED           seed random number generation
+  --vcf                 output path for the VCF file
 
 \end{verbatim}
 


### PR DESCRIPTION
Hi,

This PR introduces a new `--vcf` parameter to the `addsnv.py` script. The new parameter allows users to directly pass a VCF file path to the script, enhancing its versatility and utility.

Here are the key changes:

1. Added a new `--vcf` command-line argument.
2. Implemented processing for the input VCF file path.

This improvement simplifying the workflow and making the script more flexible and easier to use.

Thank you for considering this contribution.

Best,
Guglielmo
