### PR TITLE
Fix for ZeroDivisionError in asmregion.py when nreads is 0

### DIFF
--- a/bin/bamsurgeon/asmregion.py
+++ b/bin/bamsurgeon/asmregion.py
@@ -234,10 +234,11 @@ def asm(chrom, start, end, bamfilename, reffile, kmersize, tmpdir, mutid='null',
                 mquals.append(read.qual)
     bamfile.close()
 
-    logger.info("found " + str(nreads) + " reads in region, " + str(float(ndisc)/float(nreads)) + " discordant.")
-
     if nreads == 0:
+        logger.info("found " + str(nreads) + " reads in region.")
         return []
+    
+    logger.info("found " + str(nreads) + " reads in region, " + str(float(ndisc)/float(nreads)) + " discordant.")
 
     refseq = None
     if reffile:


### PR DESCRIPTION
Hello,

I have created a pull request addressing a bug that causes a ZeroDivisionError in `asmregion.py` script. This error originates from the line:

```python
logger.info("found " + str(nreads) + " reads in region, " + str(float(ndisc)/float(nreads)) + " discordant.")
```

This line tries to execute a division operation when nreads is zero, causing the `ZeroDivisionError: float division by zero`.

To solve this issue, I have moved up the condition that checks if nreads is zero before performing the division operation. The modified code snippet is as follows:

```python
if nreads == 0:
    logger.info("found " + str(nreads) + " reads in region.")
    return []

logger.info("found " + str(nreads) + " reads in region, " + str(float(ndisc)/float(nreads)) + " discordant.")
```

With this modification, the function now logs a message and returns an empty list when `nreads` equals zero, thus preventing the `ZeroDivisionError` from occurring.

After thoroughly testing the modifications under different scenarios, I can confirm that the fix works as expected and the program no longer crashes due to this issue.

I kindly request your review and consideration for merging this bug fix.

Thank you.