### PR TITLE
Add required param for markreads

### DIFF
--- a/bin/addsnv.py
+++ b/bin/addsnv.py
@@ -415,7 +415,7 @@ def main(args):
         if args.tagreads:
             from bamsurgeon.markreads import markreads
             tmp_tag_bam = 'tag.%s.bam' % str(uuid4())
-            markreads(outbam_mutsfile, tmp_tag_bam)
+            markreads(outbam_mutsfile, args.refFasta, tmp_tag_bam)
             move(tmp_tag_bam, outbam_mutsfile)
             logger.info("tagged reads.")
 

--- a/bin/addsv.py
+++ b/bin/addsv.py
@@ -1037,7 +1037,7 @@ def main(args):
         if args.tagreads:
             from bamsurgeon.markreads import markreads
             tmp_tag_bam = 'tag.%s.bam' % str(uuid4())
-            markreads(mergedtmp, tmp_tag_bam)
+            markreads(mergedtmp, args.refFasta, tmp_tag_bam)
             move(tmp_tag_bam, mergedtmp)
             logger.info("tagged reads.")
 


### PR DESCRIPTION
markreads requires 3 parameters - this adds the refFasta parameter for addsnv and addsv