### PR TITLE
Optimized compare_ref function from loop logic to dataframe logic. Also

### DIFF
--- a/bamsurgeon.def
+++ b/bamsurgeon.def
@@ -1,0 +1,44 @@
+Bootstrap: docker
+From: ubuntu:20.04
+
+# This definition file will allow to create a Singularity image, similar to Dockerfile
+
+%environment
+    export BAMSURGEON_PICARD_JAR=/picard.jar
+    export PATH=/app/bin:$PATH  # Force /app/bin to stay within the container
+
+%post
+    # To avoids interactive prompts during build)
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Preconfigure tzdata
+    echo "tzdata tzdata/Areas select US" | debconf-set-selections
+    echo "tzdata tzdata/Zones/US select Eastern" | debconf-set-selections
+    
+    # Install dependencies
+    apt-get update && apt-get upgrade -y
+    apt-get install -y python3 python3-pip git wget build-essential libz-dev \
+        libglib2.0-dev libbz2-dev liblzma-dev default-jre autoconf samtools bwa
+
+    mkdir -p /app/bin  # Create a custom directory for binaries
+    wget https://github.com/dzerbino/velvet/archive/refs/tags/v1.2.10.tar.gz
+    tar -xvzf v1.2.10.tar.gz
+    cd velvet-1.2.10
+    make
+    cp velvetg /app/bin
+    cp velveth /app/bin
+
+    git clone https://github.com/adamewing/exonerate.git
+    cd exonerate
+    autoreconf -fi
+    ./configure
+    make
+    make install
+
+    wget https://github.com/broadinstitute/picard/releases/download/2.27.3/picard.jar -O /picard.jar
+
+    # Install python dependencies : pysam, pandas
+    pip install pysam pandas
+
+    # Bamsurgeon
+    git clone https://github.com/adamewing/bamsurgeon.git


### PR DESCRIPTION
## Description
This pull request optimizes the `compare_ref` function for faster run of bam merging step after creating mutated bam file. In this version, I
- Modified the function to use dataframe logic instead of loop logic, using the `pandas` package to handle and compare references faster.
- Added a `bamsurgeon.def` Singularity definition file, allowing users to build a Singularity image for executing the code.
- The command to build the Singularity image is: `singularity build bamsurgeon.sif bamsurgeon.def`

## Additional Dependencies
- `pandas`
- (optional) Singularity

## Benefits
- Significantly reduced runtime by processing references more efficiently.
- Improved code readability and maintainability by using dataframe operations.

## Benchmark
### Test Setup:
- Donor BAM file size: 3GB
- Reference FASTA file: Mmul 8.0.1, consisting of 284,727 contigs (including 22 chromosomes)
- Single SNP

### Performance Improvement:
- The `addsnv.py` script execution time has been reduced from approximately 4 hours to 2-3 minutes with the optimized `compare_ref` function.

