### PR TITLE
Bugfix: only use primary mate alignments in asmregion.py

### DIFF
--- a/bin/bamsurgeon/asmregion.py
+++ b/bin/bamsurgeon/asmregion.py
@@ -215,6 +215,8 @@ def asm(chrom, start, end, bamfilename, reffile, kmersize, tmpdir, mutid='null',
     # Find the remaining reads using .mate()
     for read in pending_reads.values():
         mate = bamfile.mate(read)
+        if mate.is_supplementary or mate.is_secondary:
+            continue
         readpairs[read.qname] = ReadPair(read, mate)
 
         if read.is_read1:


### PR DESCRIPTION
Non-primary mate read alignments can cause crashes. Mate read filtering should also mirror read1 filtering, which is restricted to primary alignments.